### PR TITLE
Don't rely on ERB templating for Stripe Checkout

### DIFF
--- a/app/assets/javascripts/donations.js.coffee
+++ b/app/assets/javascripts/donations.js.coffee
@@ -13,9 +13,10 @@ IMPACT_DURATION_ONE_TIME = 'for a month'
     $('#confirmation-modal').foundation('reveal', 'open')
 
   # Load Stripe Checkout before doing anything else
-  $.getScript 'https://checkout.stripe.com/checkout.js', donationLogic
+  $.getScript 'https://checkout.stripe.com/checkout.js', ->
+    donationLogic data
 
-donationLogic = ->
+donationLogic = (data) ->
   contributionAmount = $('#contribution-amount')
   impactCount = $('#donation-impact-count')
   impactDuration = $('#donation-impact-duration')
@@ -30,8 +31,8 @@ donationLogic = ->
   amount = amountInput.filter(':checked').val()
   recurring = recurringInput.filter(':checked').val()
   stripeHandler = StripeCheckout.configure(
-    key: '<%= Figaro.env.STRIPE_PUBLISHABLE_KEY %>'
-    image: '<%= asset_url("logo.png") %>'
+    key: data.stripe_publishable_key,
+    image: data.logo_url,
     locale: 'auto'
     token: (token) ->
       # Add the Stripe token and email to the form, then submit it

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -1,5 +1,9 @@
 class DonationsController < ApplicationController
   def new
+    pluggable_js(
+      stripe_publishable_key: Figaro.env.STRIPE_PUBLISHABLE_KEY,
+      logo_url: view_context.asset_url('logo.png')
+    )
   end
 
   def create
@@ -48,7 +52,9 @@ class DonationsController < ApplicationController
     end
 
     pluggable_js(
-      donation_successful: true
+      donation_successful: true,
+      stripe_publishable_key: Figaro.env.STRIPE_PUBLISHABLE_KEY,
+      logo_url: view_context.asset_url('logo.png')
     )
 
     render :new


### PR DESCRIPTION
Previously we relied on ERB templating to inject the Stripe publishable
key and Hack Club logo URL into our JavaScript to pass to our Stripe
Checkout logic. Unfortunately that doesn't work in production because
the asset pipeline bypasses any templating that might occur.

This change takes advantage of pluggable_js to pass that data in through
a JavaScript object rendered in the view instead.

This fixes #225 to work in production.