### PR TITLE
Remove Mission Bit's EIN

### DIFF
--- a/app/views/donations/new.html.haml
+++ b/app/views/donations/new.html.haml
@@ -73,5 +73,4 @@
         %button#contribute Contribute
       %section
         %p
-          Hack Club is a registered 501(c)(3) nonprofit organization. Your
-          contribution is tax deductible.
+          Your contribution is tax deductible.

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -236,7 +236,6 @@
               San Francisco, CA 94114
     .small-12.columns.text-center
       %p.copyright
-        © #{Date.today.year} Hack Club, a 501(c)(3) non-profit [Tax ID
-        46-0945785].
+        © #{Date.today.year} Hack Club
 %script
   markersJSON = #{raw @clubs_hash.to_json}


### PR DESCRIPTION
This is just a temporary change while we file for 501(c)(3) status. Our lawyer is concerned that including an EIN on our website will confuse the IRS agent reviewing our application and they may think we're misrepresenting our non-profit status.