### PR TITLE
"See The Workshops" -> "Workshops" in navbar

### DIFF
--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -1,5 +1,5 @@
 %li= link_to 'Home', root_path
 %li= link_to 'Our Team', team_path
-%li= link_to 'See The Workshops', 'https://workshops.hackclub.com'
+%li= link_to 'Workshops', 'https://workshops.hackclub.com'
 %li= link_to 'Donate', donate_path
 %li.primary= link_to 'Start a Hack Club &raquo;'.html_safe, apply_path


### PR DESCRIPTION
This pull request changes the entry for workshops in the navbar to just say "Workshops" instead of "See The Workshops".