### PR TITLE
Don't cluster items on the map

### DIFF
--- a/app/assets/javascripts/pages.js.coffee
+++ b/app/assets/javascripts/pages.js.coffee
@@ -1,5 +1,8 @@
 @['pages#home'] = (data) ->
-  handler = Gmaps.build('Google')
+  # The markers: clusterer: undefined argument makes it so items on the map don't cluster.
+  #
+  # See docs at https://github.com/apneadiving/Google-Maps-for-Rails/wiki/Customized-Cluster-Icons#disable-clusterer-icons
+  handler = Gmaps.build('Google', markers: clusterer: undefined)
   handler.buildMap
     provider:
       center:


### PR DESCRIPTION
This pull request removes clustering on the map.

Before:

<img width="1016" alt="screen shot 2016-09-05 at 6 49 53 am" src="https://cloud.githubusercontent.com/assets/992248/18249744/01808716-7335-11e6-9584-ae89457864e0.png">

After:

<img width="946" alt="screen shot 2016-09-05 at 6 50 03 am" src="https://cloud.githubusercontent.com/assets/992248/18249752/063f2906-7335-11e6-82dd-09e277ce45e1.png">
