### PR TITLE
Proxy routes that aren't handled to the new frontend app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'figaro'
 gem 'validates_email_format_of'
 gem 'stripe'
 gem 'faraday'
+gem 'rack-proxy'
 
 group :development, :test do
   gem 'sqlite3'
@@ -34,6 +35,7 @@ group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'letter_opener'
+  gem 'byebug'
 
   gem 'rspec-rails'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    byebug (9.0.6)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -151,10 +152,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    puma (2.11.3)
-      rack (>= 1.1, < 2.0)
-    rack (1.5.2)
+    puma (3.6.2)
+    rack (1.5.5)
     rack-attack (4.3.0)
+      rack
+    rack-proxy (0.6.0)
       rack
     rack-ssl-enforcer (0.2.8)
     rack-test (0.6.2)
@@ -284,6 +286,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  byebug
   capybara
   coffee-rails (~> 4.0.0)
   email_spec
@@ -303,6 +306,7 @@ DEPENDENCIES
   pluggable_js
   puma
   rack-attack
+  rack-proxy
   rack-ssl-enforcer
   rack-timeout
   rails (= 4.1.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,9 @@ module HackClub
     # Also use Rack::Deflater for runtime asset compression
     config.middleware.insert_before ActionDispatch::Static, Rack::Deflater
 
+    # Autoload files from lib/
+    config.autoload_paths << Rails.root.join('lib')
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,6 @@ Rails.application.routes.draw do
   %w[how_it_works sponsor team].each do |page|
     get page, controller: 'pages', action: page
   end
+
+  match '*path', to: AppProxy.new, via: :all
 end

--- a/lib/app_proxy.rb
+++ b/lib/app_proxy.rb
@@ -1,0 +1,23 @@
+class AppProxy < Rack::Proxy
+  def rewrite_env(env)
+    env['HTTP_HOST'] = 'new.hackclub.com'
+    env['SERVER_PORT'] = '443'
+    env['HTTPS'] = 'on'
+
+    # Always force the proxy to correspond to the "root" of the application.
+    #
+    # See http://www.rubydoc.info/github/rack/rack/file/SPEC#The_Environment for
+    # an explanation on how SCRIPT_NAME works in Rack.
+    env['SCRIPT_NAME'] = nil
+
+    # Strip forwarding parameters, so the app doesn't know it's being accessed
+    # through a reverse proxy
+    env['HTTP_X_FORWARDED_SCHEME'] = nil
+    env['HTTP_X_FORWARDED_PROTO'] = nil
+    env['HTTP_X_FORWARDED_HOST'] = nil
+    env['HTTP_X_FORWARDED_PORT'] = nil
+    env['HTTP_X_FORWARDED_SSL'] = nil
+
+    env
+  end
+end


### PR DESCRIPTION
This change causes the Rails app to proxy requests that aren't handled by a route to https://github.com/hackclub/frontend. This'll allow us to seamlessly transition over to the new frontend app without having to send our users to multiple domains.