### PR TITLE
Disable Turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'rack-attack'
 gem 'unf_ext'
 
 gem 'jquery-rails'
-gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'foundation-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,8 +263,6 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.6.0)
@@ -320,7 +318,6 @@ DEPENDENCIES
   sqlite3
   stripe
   therubyracer
-  turbolinks
   uglifier (>= 1.3.0)
   unf_ext
   validates_email_format_of

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require foundation
-//= require turbolinks
 //= require underscore
 //= require gmaps/google
 //= require_tree .

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,8 +7,7 @@
     %title= full_title(yield(:title))
 
     = favicon_link_tag 'favicon.ico'
-    = stylesheet_link_tag 'application', media: 'all',
-        'data-turbolinks-track' => true
+    = stylesheet_link_tag 'application', media: 'all'
     = csrf_meta_tags
   %body
     .off-canvas-wrap{ 'data-offcanvas' => '' }
@@ -40,5 +39,5 @@
     = javascript_include_tag "//maps.google.com/maps/api/js?v=3.24&key=#{Figaro.env.GOOGLE_MAPS_KEY}"
     = javascript_include_tag '//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js'
     = javascript_include_tag '//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js'
-    = javascript_include_tag 'application', 'data-turbolinks-track' => true
+    = javascript_include_tag 'application'
     = javascript_pluggable_tag


### PR DESCRIPTION
Turbolinks has been causing problems with Google Maps and now causes issues with the proxy introduced in #280. Kill it with fire!