### PR TITLE
Fix application email blocks

### DIFF
--- a/app/mailers/club_application_mailer.rb
+++ b/app/mailers/club_application_mailer.rb
@@ -1,5 +1,5 @@
 class ClubApplicationMailer < ActionMailer::Base
-  default from: 'Zach Latta <team@hackclub.com>'
+  default from: 'Hack Club Team <team@hackclub.com>'
 
   def applicant_confirmation(application)
     @application = application
@@ -13,7 +13,7 @@ class ClubApplicationMailer < ActionMailer::Base
     @application = application
 
     to = Mail::Address.new 'team@hackclub.com'
-    to.display_name = 'Zach Latta'
+    to.display_name = 'Hack Club Team'
     mail(to: to.format, from: @application.mail_address.format,
          subject: 'Hack Club Application')
   end

--- a/app/mailers/club_application_mailer.rb
+++ b/app/mailers/club_application_mailer.rb
@@ -14,7 +14,7 @@ class ClubApplicationMailer < ActionMailer::Base
 
     to = Mail::Address.new 'team@hackclub.com'
     to.display_name = 'Hack Club Team'
-    mail(to: to.format, from: @application.mail_address.format,
+    mail(to: to.format, reply_to: @application.mail_address.format,
          subject: 'Hack Club Application')
   end
 end

--- a/spec/mailers/club_application_mailer_spec.rb
+++ b/spec/mailers/club_application_mailer_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe ClubApplicationMailer, type: :mailer do
 
     it { should have_subject 'Hack Club Application' }
     it { should deliver_to 'Hack Club Team <team@hackclub.com>' }
-    it { should deliver_from application.mail_address.format }
+    it { should deliver_from 'Hack Club Team <team@hackclub.com>' }
+    it { should reply_to application.mail_address.format }
 
     it_behaves_like 'a club application email'
   end

--- a/spec/mailers/club_application_mailer_spec.rb
+++ b/spec/mailers/club_application_mailer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ClubApplicationMailer, type: :mailer do
 
     it { should have_subject 'Application Confirmation' }
     it { should deliver_to application.mail_address.format }
-    it { should deliver_from 'Zach Latta <team@hackclub.com>' }
+    it { should deliver_from 'Hack Club Team <team@hackclub.com>' }
 
     it_behaves_like 'a club application email'
   end
@@ -41,7 +41,7 @@ RSpec.describe ClubApplicationMailer, type: :mailer do
     subject { ClubApplicationMailer.admin_notification(application) }
 
     it { should have_subject 'Hack Club Application' }
-    it { should deliver_to 'Zach Latta <team@hackclub.com>' }
+    it { should deliver_to 'Hack Club Team <team@hackclub.com>' }
     it { should deliver_from application.mail_address.format }
 
     it_behaves_like 'a club application email'


### PR DESCRIPTION
There's currently a problem where our SMTP provider, SendGrid, is refusing to
send some of the applications we receive because we're sending them from the
applicant's email address.

This change sends the application notifications from 'Hack Club Team' and,
instead, sets the applicant's email as the Reply-To value.