### PR TITLE
Use unique email subjects for new application notifications

### DIFF
--- a/app/mailers/club_application_mailer.rb
+++ b/app/mailers/club_application_mailer.rb
@@ -5,7 +5,7 @@ class ClubApplicationMailer < ActionMailer::Base
     @application = application
 
     to = Mail::Address.new @application.email
-    to.display_name = "#{@application.first_name} #{@application.last_name}"
+    to.display_name = @application.full_name
     mail(to: to.format, subject: 'Application Confirmation')
   end
 
@@ -14,7 +14,10 @@ class ClubApplicationMailer < ActionMailer::Base
 
     to = Mail::Address.new 'team@hackclub.com'
     to.display_name = 'Hack Club Team'
+
+    subject = "Hack Club Application (#{@application.full_name}, #{@application.high_school})"
+
     mail(to: to.format, reply_to: @application.mail_address.format,
-         subject: 'Hack Club Application')
+         subject: subject)
   end
 end

--- a/app/models/club_application.rb
+++ b/app/models/club_application.rb
@@ -18,7 +18,11 @@ class ClubApplication < ActiveRecord::Base
 
   def mail_address
     expected = Mail::Address.new email
-    expected.display_name = "#{first_name} #{last_name}"
+    expected.display_name = full_name
     return expected
+  end
+
+  def full_name
+    "#{first_name} #{last_name}"
   end
 end

--- a/app/views/club_applications/_club_application.text.erb
+++ b/app/views/club_applications/_club_application.text.erb
@@ -1,4 +1,4 @@
-Name: <%= club_application.first_name %> <%= club_application.last_name %>
+Name: <%= club_application.full_name %>
 High school: <%= club_application.high_school %>
 Year: <%= club_application.year %>
 Email: <%= club_application.email %>

--- a/spec/mailers/club_application_mailer_spec.rb
+++ b/spec/mailers/club_application_mailer_spec.rb
@@ -40,7 +40,13 @@ RSpec.describe ClubApplicationMailer, type: :mailer do
   describe 'admin notification' do
     subject { ClubApplicationMailer.admin_notification(application) }
 
-    it { should have_subject 'Hack Club Application' }
+    it 'has the correct subject' do
+      expected = 'Hack Club Application '\
+                 "(#{application.full_name}, #{application.high_school})"
+
+      expect(subject).to have_subject expected
+    end
+
     it { should deliver_to 'Hack Club Team <team@hackclub.com>' }
     it { should deliver_from 'Hack Club Team <team@hackclub.com>' }
     it { should reply_to application.mail_address.format }

--- a/spec/models/club_application_spec.rb
+++ b/spec/models/club_application_spec.rb
@@ -36,9 +36,16 @@ RSpec.describe ClubApplication, type: :model do
 
   describe '#mail_address' do
     it 'returns a correctly formatted mail address' do
-      expected =
-        "#{subject.first_name} #{subject.last_name} <#{subject.email}>"
+      expected = "#{subject.full_name} <#{subject.email}>"
       expect(subject.mail_address.format).to eq expected
+    end
+  end
+
+  describe '#full_name' do
+    it 'returns a correctly formatted full name' do
+      expected = "#{subject.first_name} #{subject.last_name}"
+
+      expect(subject.full_name).to eq expected
     end
   end
 end


### PR DESCRIPTION
Gmail threads by some combination of subject and sender. This causes a problem
when the subject for every Hack Club application is "Hack Club Application" -- a
bunch of applications end up getting threaded together, causing issues with
Streak.

This change fixes that issue by changing the notification subject to "Hack Club
Application ({Applicant Name}, {Applicant School})", which will cause Gmail to
create new threads for each new application.