### PR TITLE
Fix quote on mobile

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -891,6 +891,10 @@ a {
     p {
       font-size: 18px;
       font-weight: 300;
+
+      @media #{$small-only} {
+        font-style: italic;
+      }
     }
 
     .quotee-img {
@@ -906,5 +910,9 @@ a {
     left: -10px;
     position: absolute;
     top: -30px;
+
+    @media #{$small-only} {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
This is a temporary fixed which improves the styling of the testimonial quote. Previously the apostrophe was completely jank on < `medium` screens.

I'm really sorry that we had something which looked that horrible in production – that really shouldn't have happened.