### PR TITLE
Add chat bubble testimonial

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -914,6 +914,10 @@ a {
   border: 0.75em solid $hackclub-black;
   background-color: $hackclub-white;
   color: $hackclub-black;
+
+  p {
+    margin-bottom: 0;
+  }
 }
 
 .chat-bubble-arrow {

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -911,7 +911,9 @@ a {
 
 .chat-bubble {
   padding: 0.5em;
-  border: 0.75em solid $hackclub-white;
+  border: 0.75em solid $hackclub-black;
+  background-color: $hackclub-white;
+  color: $hackclub-black;
 }
 
 .chat-bubble-arrow {
@@ -919,7 +921,7 @@ a {
   content: ' ';
   border: 40px solid;
   border-top-width: 0;
-  border-color: $hackclub-white $hackclub-white transparent transparent;
+  border-color: $hackclub-black $hackclub-black transparent transparent;
 
   @media #{$small-only} {
     margin-right: 0;

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -890,7 +890,6 @@ a {
     }
 
     .quotee-img {
-      border-radius: 5%;
       width: 100%;
     }
   }
@@ -901,8 +900,8 @@ a {
 }
 
 .chat-bubble {
-  padding: 0.75em;
-  border: 4px solid $hackclub-black;
+  padding: 1em;
+  border: 4px solid $hackclub-white;
   background-color: $hackclub-white;
   color: $hackclub-black;
 
@@ -914,7 +913,19 @@ a {
 .chat-bubble-arrow {
   margin-left: 80%;
   content: ' ';
-  border: 40px solid;
+  border: 35px solid;
   border-top-width: 0;
-  border-color: transparent transparent transparent $hackclub-black;
+  border-color: transparent transparent transparent $hackclub-white;
+}
+
+.chat-flex {
+  display: flex;
+}
+
+.chat-info {
+  align-self: center;
+
+  h3, h4 {
+    margin: 0;
+  }
 }

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -883,10 +883,6 @@ a {
 }
 
 .testimonials {
-  h2 {
-    text-align: center;
-  }
-
   .testimonial {
     p {
       font-size: 18px;
@@ -899,19 +895,14 @@ a {
     }
   }
 
-  .quotation-mark {
-    content: "\201C";
-    display: block;
-    font-size: 60px;
-    left: -10px;
-    position: absolute;
-    top: -30px;
+  h3 {
+    margin-bottom: 0;
   }
 }
 
 .chat-bubble {
-  padding: 0.5em;
-  border: 0.75em solid $hackclub-black;
+  padding: 0.75em;
+  border: 4px solid $hackclub-black;
   background-color: $hackclub-white;
   color: $hackclub-black;
 
@@ -921,13 +912,9 @@ a {
 }
 
 .chat-bubble-arrow {
-  margin-right: 10%;
+  margin-left: 80%;
   content: ' ';
   border: 40px solid;
   border-top-width: 0;
-  border-color: $hackclub-black $hackclub-black transparent transparent;
-
-  @media #{$small-only} {
-    margin-right: 0;
-  }
+  border-color: transparent transparent transparent $hackclub-black;
 }

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -908,3 +908,20 @@ a {
     top: -30px;
   }
 }
+
+.chat-bubble {
+  padding: 0.5em;
+  border: 0.75em solid $hackclub-white;
+}
+
+.chat-bubble-arrow {
+  margin-right: 10%;
+  content: ' ';
+  border: 40px solid;
+  border-top-width: 0;
+  border-color: $hackclub-white $hackclub-white transparent transparent;
+
+  @media #{$small-only} {
+    margin-right: 0;
+  }
+}

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -17,12 +17,13 @@
   .row.testimonials
     .medium-6.medium-offset-3.columns.testimonials
       .testimonial
-        %p
-          %span.quotation-mark &ldquo;
-          At one of our first meetings, a sophomore thanked me for starting the
-          club because it showed her that coding is about more than taking a
-          test. Hack Club showed my school what computer science classes didn't
-          and let me share why I care about coding.
+        .chat-bubble
+          %p
+            At one of our first meetings, a sophomore thanked me for starting the
+            club because it showed her that coding is about more than taking a
+            test. Hack Club showed my school what computer science classes didn't
+            and let me share why I care about coding.
+        .chat-bubble-arrow
         .row
           .small-3.columns
             = image_tag 'testimonials/rachel_sterneck.png', class: 'quotee-img'

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -24,10 +24,10 @@
             test. Hack Club showed my school what computer science classes didn't
             and let me share why I care about coding.
         .chat-bubble-arrow
-        .row
+        .row.chat-flex
           .small-3.columns
             = image_tag 'testimonials/rachel_sterneck.png', class: 'quotee-img'
-          .small-9.columns
+          .small-9.columns.chat-info
             %h3 Rachel Sterneck
             %h4 Senior, Roslyn High School
 #how-it-works


### PR DESCRIPTION
This PR changes the design around our testimonials to be `chat bubble orientated`. It's this super hip new design trend. TLDR: put everything in a chat bubble.

Initial design on desktop:

![screenshot 2017-02-15 14 31 50](https://cloud.githubusercontent.com/assets/8407370/22998920/e4140ae8-f38d-11e6-8895-5bc5e990ea1d.png)

Initial design on mobile:

![screenshot 2017-02-15 14 31 14](https://cloud.githubusercontent.com/assets/8407370/22998928/ebdda356-f38d-11e6-89d1-f99bf0c5b5cf.png)

Relevant Slack discussion:

> **harrison** [2:35 PM] 
> @zrl @msw: thoughts on the design here?
> 
> **zrl** [2:41 PM] 
> not a fan
> what if you did rounded corners, filled in the entire text bubble with white, and made he text black?
>
> **harrison** [2:42 PM] 
> personally, i thought that looked weird – most of the other corners on our site are hard.
> i’ll try that now
>
> **zrl** [2:42 PM] 
> and then also flipped the triangle in the bottom right to face the profile picture
> yeah, that's fair
> @msw will probably have way better feedback than me

I'd appreciate any feedback on the design.