### PR TITLE
Guess if submitted applications are spam

### DIFF
--- a/app/models/club_application.rb
+++ b/app/models/club_application.rb
@@ -25,4 +25,8 @@ class ClubApplication < ActiveRecord::Base
   def full_name
     "#{first_name} #{last_name}"
   end
+
+  def is_spam?
+    ApplicationSpamService.new.is_spam?(self)
+  end
 end

--- a/app/services/application_spam_service.rb
+++ b/app/services/application_spam_service.rb
@@ -1,0 +1,18 @@
+class ApplicationSpamService
+  WORD_CUTOFF = 5
+
+  def is_spam?(application)
+    if word_count(application.interesting_project) <= WORD_CUTOFF &&
+       word_count(application.system_hacked) <= WORD_CUTOFF
+      return true
+    end
+
+    false
+  end
+
+  private
+
+  def word_count(phrase)
+    phrase.split(' ').length
+  end
+end

--- a/app/views/club_applications/_club_application.text.erb
+++ b/app/views/club_applications/_club_application.text.erb
@@ -5,6 +5,7 @@ Email: <%= club_application.email %>
 Phone number: <%= club_application.phone_number %>
 GitHub: <%= club_application.github %>
 Twitter: <%= club_application.twitter %>
+Suspected spam: <%= club_application.is_spam? %>
 
 
 Please tell us about an interesting project, preferably outside of

--- a/spec/mailers/club_application_mailer_spec.rb
+++ b/spec/mailers/club_application_mailer_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe ClubApplicationMailer, type: :mailer do
         expect(subject).to_not have_body_text(f)
       end
     end
+
+    it 'shows whether the application is spam' do
+      text = "Suspected spam: #{application.is_spam?}"
+      expect(subject).to have_body_text(text)
+    end
   end
 
   let(:application) { create(:club_application) }

--- a/spec/models/club_application_spec.rb
+++ b/spec/models/club_application_spec.rb
@@ -48,4 +48,15 @@ RSpec.describe ClubApplication, type: :model do
       expect(subject.full_name).to eq expected
     end
   end
+
+  describe '#is_spam?' do
+    it 'calls #is_spam? on ApplicationSpamService' do
+      service = ApplicationSpamService.new
+
+      expect(ApplicationSpamService).to receive(:new).and_return(service)
+      expect(service).to receive(:is_spam?).with(subject)
+
+      subject.is_spam?
+    end
+  end
 end

--- a/spec/services/application_spam_service_spec.rb
+++ b/spec/services/application_spam_service_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationSpamService, type: :model do
+  SHORT_ANSWER_LENGTH = 5
+
+  let(:base_app) { create(:club_application) }
+  let(:short_answer) { Faker::Lorem.words(SHORT_ANSWER_LENGTH).join(' ') }
+
+  describe '#is_spam?' do
+    it 'returns false with a legit application' do
+      expect(ApplicationSpamService.new.is_spam?(base_app)).to eq(false)
+    end
+
+    it 'returns true with a spam application' do
+      base_app.system_hacked = short_answer
+      base_app.interesting_project = short_answer
+
+      expect(ApplicationSpamService.new.is_spam?(base_app)).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new section to submitted application emails (that are sent to the staff) that guesses whether the application is spam.

Before this change:

```
New application for Hack Club received:


Name: Zach Latta
High school: El Segundo High School
Year: eleven
Email: zach@zachlatta.com
Phone number: [redacted]
GitHub: zachlatta
Twitter: zachlatta


Please tell us about an interesting project, preferably outside of
class, that you created or worked on.

asdf asdf
...
```

After this change:

```
New application for Hack Club received:


Name: Zach Latta
High school: El Segundo High School
Year: twelve
Email: zach@zachlatta.com
Phone number: [redacted]
GitHub: zachlatta
Twitter: zachlatta
Suspected spam: false


Please tell us about an interesting project, preferably outside of
class, that you created or worked on.

asdf; asdfa sfasdf asdfasdf asdf sadf asf sdf asdf sadf asdf asdf asdf asdf sadf asdf asdf asdf
...
```