### PR TITLE
Add start_date field

### DIFF
--- a/app/controllers/club_applications_controller.rb
+++ b/app/controllers/club_applications_controller.rb
@@ -21,6 +21,7 @@ class ClubApplicationsController < ApplicationController
   def club_application_params
     params.require(:club_application).permit(:first_name, :last_name, :email,
                                              :phone_number, :github, :twitter,
+                                             :start_date,
                                              :high_school, :year,
                                              :interesting_project,
                                              :system_hacked, :steps_taken,

--- a/app/models/club_application.rb
+++ b/app/models/club_application.rb
@@ -1,5 +1,5 @@
 class ClubApplication < ActiveRecord::Base
-  validates_presence_of :first_name, :last_name, :email, :high_school, :year,
+  validates_presence_of :first_name, :last_name, :email, :high_school, :year, :start_date,
     :interesting_project, :system_hacked, :steps_taken, :referer
   validates_uniqueness_of :email
   validates_email_format_of :email, message: 'not a valid email'
@@ -15,6 +15,14 @@ class ClubApplication < ActiveRecord::Base
     parent_or_guardian: 7,
     other: 8
   }
+
+  def self.next_12_months(from = Time.now)
+    (0..12).map do |i|
+      to = from + (1.month * i)
+
+      "#{Date::MONTHNAMES[to.month]} #{to.year}"
+    end
+  end
 
   def mail_address
     expected = Mail::Address.new email

--- a/app/views/club_applications/_club_application.text.erb
+++ b/app/views/club_applications/_club_application.text.erb
@@ -6,6 +6,7 @@ Phone number: <%= club_application.phone_number %>
 GitHub: <%= club_application.github %>
 Twitter: <%= club_application.twitter %>
 Suspected spam: <%= club_application.is_spam? %>
+Start date: <%= club_application.start_date %>
 
 
 Please tell us about an interesting project, preferably outside of

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -54,6 +54,10 @@
               %span.prefix twitter.com/
             .small-8.columns
               = f.input :twitter, label: false, placeholder: 'zaphod'
+      .row
+        .large-12.columns
+          = f.input :start_date, label: 'Start date', as: :select,
+            collection: ["ASAP"] + ClubApplication.next_12_months
     %fieldset
       %legend Application
       .row

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -9,7 +9,6 @@
 .row
   .small-12.medium-9.small-centered.columns
     %p.apply-info
-      We're currently accepting applications for the 2016 - 2017 school year.
       If you have any questions, feel free to message us from the bottom
       right-hand corner – we'll get back to you ASAP. You should probably be
       writing over 3 sentences per response, just make sure you don't write an

--- a/db/migrate/20170502211535_add_start_date_to_club_application.rb
+++ b/db/migrate/20170502211535_add_start_date_to_club_application.rb
@@ -1,0 +1,5 @@
+class AddStartDateToClubApplication < ActiveRecord::Migration
+  def change
+    add_column :club_applications, :start_date, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170207021033) do
+ActiveRecord::Schema.define(version: 20170502211535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20170207021033) do
     t.integer  "year"
     t.text     "referer"
     t.string   "phone_number"
+    t.text     "start_date"
   end
 
   add_index "club_applications", ["email"], name: "index_club_applications_on_email", unique: true, using: :btree

--- a/spec/factories/club_applications.rb
+++ b/spec/factories/club_applications.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     year { ClubApplication.years.keys.sample.to_sym }
     github { Faker::Internet.user_name }
     twitter { Faker::Internet.user_name }
+    start_date { Faker::Date.between(Time.now, Time.now + 1.year).strftime('%B %Y') }
     interesting_project { Faker::Lorem.paragraph }
     system_hacked { Faker::Lorem.paragraph }
     steps_taken { Faker::Lorem.paragraph }

--- a/spec/models/club_application_spec.rb
+++ b/spec/models/club_application_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ClubApplication, type: :model do
   it { should respond_to :year }
   it { should respond_to :github }
   it { should respond_to :twitter }
+  it { should respond_to :start_date }
   it { should respond_to :interesting_project }
   it { should respond_to :system_hacked }
   it { should respond_to :steps_taken }


### PR DESCRIPTION
We're going to use this field as a sort of waitlist. Clubs with "ASAP"
or the current/next month as their start_date will be onboarded
immediately, while everyone else will only be onboarded when the month
they designated comes around.