### PR TITLE
Fix how the reverse proxy interacts with SSL hosts

### DIFF
--- a/lib/app_proxy.rb
+++ b/lib/app_proxy.rb
@@ -5,7 +5,6 @@ class AppProxy
     Rack::Builder.new do
       use Rack::ReverseProxy do
         reverse_proxy '/', 'https://new.hackclub.com'
-        reverse_proxy_options force_ssl: true
       end
 
       # Don't return for any request that somehow passes through the reverse


### PR DESCRIPTION
For some unholy reason, the current deployment returns this when proxying an SSL host:

![screen shot 2017-05-10 at 5 10 54 pm](https://cloud.githubusercontent.com/assets/992248/25926364/b0ed9e92-35a3-11e7-95fa-787b0b676e68.png)

For some reason, this PR fixes this.